### PR TITLE
Clean up POM to remove some leftovers from signalk-server-java

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,9 +3,10 @@
 /signalk-static
 /storage
 
-# exclude eclipse stuff
+# exclude IDE stuff
 .settings
 .project
 .classpath
-
+.idea
+*.iml
 

--- a/pom.xml
+++ b/pom.xml
@@ -1,28 +1,24 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>nz.co.fortytwo.signalk.core</groupId>
 	<artifactId>signalk-core</artifactId>
 	<version>0.0.1-SNAPSHOT</version>
 	<name>signalk-core</name>
+
 	<properties>
 	  <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	  <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-	  <!-- <bundle.name>nsb-${project.version}</bundle.name> -->
-		<jetty.version>9.2.9.v20150224</jetty.version>
-		<!-- <camel.version>2.14.1</camel.version> -->
-		<!-- <camel.core.version>2.14.1</camel.core.version> -->
-		<jna.version>3.6.0-SNAPSHOT</jna.version>
-		<geotools.version>12-RC1</geotools.version>
-		<surefire.plugin.version>2.19</surefire.plugin.version>
 	</properties>
+
 	<licenses>
-		<license>
-			<name>APACHE LICENSE, Version 2</name>
-			<url>http://www.apache.org/licenses/LICENSE-2.0</url>
-			<distribution>repo</distribution>
-		</license>
+    <license>
+      <name>Apache License, Version 2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <distribution>repo</distribution>
+    </license>
 	</licenses>
+
 	<organization>
 		<name>Tasman Consulting Ltd</name>
 		<url>www.42.co.nz</url>
@@ -34,66 +30,36 @@
 			<email>robert@42.co.nz</email>
 		</developer>
 	</developers>
-	<repositories>
-		<repository>
-			<id>java.net jni</id>
-			<name>java.nt JNI Snapshot Repository</name>
-			<url>https://maven.java.net/content/repositories/snapshots/</url>
-		</repository>
-		<repository>
-			<id>PJC</id>
-			<name>Sparetime Repository</name>
-			<url>http://www.sparetimelabs.com/maven2</url>
-		</repository>
-		<repository>
-			<id>dma AIS</id>
-			<name>DMA AisLib Repository</name>
-			<url>http://repository-dma.forge.cloudbees.com/release</url>
-		</repository>
-		<repository>
-			<id>maven-restlet</id>
-			<name>Public online Restlet repository</name>
-			<url>http://maven.restlet.com</url>
-		</repository>
-	</repositories>
-	<pluginRepositories>
-		<pluginRepository>
-			<id>autoincrement-versions-maven-plugin</id>
-			<name>autoincrement-versions-maven-plugin</name>
-			<url>http://autoincrement-versions-maven-plugin.googlecode.com/svn/repo</url>
-			<snapshots>
-				<enabled>true</enabled>
-			</snapshots>
-		</pluginRepository>
 
-	</pluginRepositories>
+  <repositories>
+    <repository>
+      <id>dma AIS</id>
+      <name>DMA AisLib Repository</name>
+      <url>http://repository-dma.forge.cloudbees.com/release</url>
+    </repository>
+  </repositories>
 
 	<dependencies>
-		<!-- serial comms -->
-
-		<!-- jna LGPL, Apache <dependency> <groupId>net.java.dev.jna</groupId> 
-			<artifactId>jna</artifactId> <version>${jna.version}</version> </dependency> -->
-		<!-- BSD <dependency> <groupId>com.sparetimelabs</groupId> <artifactId>purejavacomm</artifactId> 
-			<version>0.0.21</version> </dependency> -->
-
-		<!-- ais -->
-
 		<!-- ais Apache licence -->
-		<!-- <module>ais-lib-messages</module> -->
-		<!-- <module>ais-lib-utils</module> -->
-		<!-- <module>ais-lib-cli</module> -->
 		<dependency>
 			<groupId>dk.dma.ais.lib</groupId>
 			<artifactId>ais-lib-communication</artifactId>
 			<version>2.1</version>
 		</dependency>
-		<!-- json - Apache licence <dependency> <groupId>org.sharegov</groupId> 
-			<artifactId>mjson</artifactId> <version>1.3</version> </dependency> -->
+
+    <!-- JSON -->
+    <dependency>
+      <groupId>com.jayway.jsonpath</groupId>
+      <artifactId>json-path</artifactId>
+      <version>1.2.0</version>
+    </dependency>
+
 		<dependency>
 			<groupId>javax.servlet</groupId>
 			<artifactId>javax.servlet-api</artifactId>
 			<version>3.1.0</version>
 		</dependency>
+
 		<!-- commons and misc = apache licence -->
 		<dependency>
 			<groupId>commons-codec</groupId>
@@ -106,21 +72,25 @@
 			<version>3.4</version>
 		</dependency>
 		<dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-log4j12</artifactId>
-			<version>1.6.6</version>
+			<groupId>commons-io</groupId>
+			<artifactId>commons-io</artifactId>
+			<version>2.4</version>
 		</dependency>
+
+		<!-- Logging -->
 		<dependency>
 			<groupId>log4j</groupId>
 			<artifactId>log4j</artifactId>
 			<version>1.2.17</version>
 		</dependency>
+
 		<!-- time - apache licence -->
 		<dependency>
 			<groupId>joda-time</groupId>
 			<artifactId>joda-time</artifactId>
 			<version>2.4</version>
 		</dependency>
+
 		<!-- nmea LGPL 3 -->
 		<dependency>
 			<groupId>net.sf.marineapi</groupId>
@@ -133,54 +103,22 @@
 				</exclusion>
 			</exclusions>
 		</dependency>
+
 		<!-- jGit -->
 		<dependency>
 			<groupId>org.eclipse.jgit</groupId>
 			<artifactId>org.eclipse.jgit</artifactId>
 			<version>4.0.0.201505050340-m2</version>
 		</dependency>
-		<!-- commons -->
-		<dependency>
-			<groupId>commons-logging</groupId>
-			<artifactId>commons-logging</artifactId>
-			<version>1.1.1</version>
-		</dependency>
-		<dependency>
-			<groupId>commons-io</groupId>
-			<artifactId>commons-io</artifactId>
-			<version>2.4</version>
-		</dependency>
 
-
-		<!-- <dependency> <groupId>commons-lang</groupId> <artifactId>commons-lang</artifactId> 
-			<version>2.4</version> </dependency> -->
-		<!-- <dependency> <groupId>org.apache.commons</groupId> <artifactId>commons-exec</artifactId> 
-			<version>1.1</version> </dependency> -->
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
 			<version>4.11</version>
 			<scope>test</scope>
 		</dependency>
-		<!-- xml BSD -->
-		<dependency>
-			<groupId>dom4j</groupId>
-			<artifactId>dom4j</artifactId>
-			<version>1.6.1</version>
-		</dependency>
+
 		<!-- test http and ws - Apache lic -->
-		<dependency>
-			<groupId>com.jayway.jsonpath</groupId>
-			<artifactId>json-path</artifactId>
-			<version>1.2.0</version>
-		</dependency>
-		<!-- <dependency> -->
-		<!-- <groupId>com.ning</groupId> -->
-		<!-- <artifactId>async-http-client</artifactId> -->
-		<!-- <version>1.8.14</version> -->
-		<!-- <scope>test</scope> -->
-		<!-- </dependency> -->
-		<!-- apache -->
 		<dependency>
 			<groupId>com.cedarsoftware</groupId>
 			<artifactId>json-io</artifactId>
@@ -193,31 +131,10 @@
 			<version>2.0.5-beta</version>
 			<scope>test</scope>
 		</dependency>
-
 	</dependencies>
+
 	<build>
 		<plugins>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-surefire-plugin</artifactId>
-				<version>${surefire.plugin.version}</version>
-				<configuration>
-					<forkCount>1</forkCount>
-					<reuseForks>false</reuseForks>
-					<argLine>-Xmx512m -XX:MaxPermSize=32m</argLine>
-				</configuration>
-			</plugin>
-
-			<!-- Allows the example to be run via 'mvn compile exec:java' <plugin> 
-				<groupId>org.codehaus.mojo</groupId> <artifactId>exec-maven-plugin</artifactId> 
-				<configuration> <mainClass>nz.co.fortytwo.signalk.server.ServerMain</mainClass> 
-				<includePluginDependencies>false</includePluginDependencies> </configuration> 
-				</plugin> -->
-			<plugin>
-				<groupId>org.eclipse.jetty</groupId>
-				<artifactId>jetty-maven-plugin</artifactId>
-				<version>${jetty.version}</version>
-			</plugin>
 			<plugin>
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.0</version>
@@ -226,39 +143,6 @@
 					<target>1.7</target>
 				</configuration>
 			</plugin>
-			<plugin>
-				<artifactId>maven-assembly-plugin</artifactId>
-				<version>2.2.1</version>
-				<!-- Tell Maven when to execute this plugin -->
-				<executions>
-					<execution>
-						<id>make-assembly-jar</id>
-						<phase>package</phase>
-						<configuration>
-							<descriptorRefs>
-								<!-- Tell Maven-Assembly to include dependencies in jar -->
-								<descriptorId>jar-with-dependencies</descriptorId>
-							</descriptorRefs>
-							<archive>
-								<manifest>
-									<!-- Specify class to be run at startup <mainClass>nz.co.fortytwo.signalk.server.SignalKServer</mainClass> -->
-								</manifest>
-							</archive>
-						</configuration>
-						<goals>
-							<goal>single</goal>
-						</goals>
-					</execution>
-					<!-- <execution> <id>make-assembly-zip</id> <phase>package</phase> <configuration> 
-						<descriptors> <descriptor>src/main/release/assembly.xml</descriptor> </descriptors> 
-						</configuration> <goals> <goal>single</goal> </goals> </execution> -->
-				</executions>
-			</plugin>
-			<!-- <plugin> <groupId>org.codehaus.mojo</groupId> <artifactId>autoincrement-versions-maven-plugin</artifactId> 
-				<version>2.0-SNAPSHOT</version> <executions> <execution> <id>update-pom-versions</id> 
-				<goals> <goal>increment</goal> <goal>commit</goal> </goals> <phase>install</phase> 
-				<configuration> <autoIncrementVersion>true</autoIncrementVersion> </configuration> 
-				</execution> </executions> </plugin> -->
 		</plugins>
 	</build>
 </project>


### PR DESCRIPTION
Removed repository and dependencies that are not needed by this jar.
Remove assembly that included dependencies figuring projects that use this jar (like -server) would do that.
Added ignores for IDEA as well as Eclipse
