### PR TITLE
Making SignalK Java Core more Android Friendly

### DIFF
--- a/src/main/java/nz/co/fortytwo/signalk/model/impl/SignalKModelFactory.java
+++ b/src/main/java/nz/co/fortytwo/signalk/model/impl/SignalKModelFactory.java
@@ -48,7 +48,10 @@ public class SignalKModelFactory {
 	private static final String SIGNALK_CFG_SAVE_FILE = "./conf/signalk-config.json";
 	private static Logger logger = Logger.getLogger(SignalKModelFactory.class);
 	private static SignalKModel signalKModel;
+	private static String rootPath="";
+
 	static {
+		rootPath=Util.getRootPath();
 		if (signalKModel == null)
 			signalKModel = new SignalKModelImpl();
 		Util.setDefaults(signalKModel);
@@ -104,14 +107,14 @@ public class SignalKModelFactory {
 	}
 
 	public static void load(SignalKModel model){
-		File jsonFile = new File(SIGNALK_MODEL_SAVE_FILE);
+		File jsonFile = new File(rootPath+SIGNALK_MODEL_SAVE_FILE);
 		logger.info("Checking for previous state: "+jsonFile.getAbsolutePath());
 		if(jsonFile.exists()){
 			try{
 				Json temp = Json.read(jsonFile.toURI().toURL());
 				JsonSerializer ser = new JsonSerializer();
 				model.putAll(ser.read(temp));
-				logger.info("   Saved state loaded from "+SIGNALK_MODEL_SAVE_FILE);
+				logger.info("   Saved state loaded from "+rootPath+SIGNALK_MODEL_SAVE_FILE);
 			}catch(Exception ex){
 				logger.error(ex.getMessage());
 			}
@@ -120,7 +123,7 @@ public class SignalKModelFactory {
 		}
 	}
 	public static void loadConfig(SignalKModel model) throws IOException{
-		File jsonFile = new File(SIGNALK_CFG_SAVE_FILE);
+		File jsonFile = new File(rootPath+SIGNALK_CFG_SAVE_FILE);
 		logger.info("Checking for previous config: "+jsonFile.getAbsolutePath());
 		if(jsonFile.exists()){
 			try{
@@ -132,7 +135,7 @@ public class SignalKModelFactory {
 				Util.setSelf(SignalKConstants.self);
 				model.put(SignalKConstants.vessels_dot_self_dot+"uuid", self);
 				
-				logger.info("   Saved config loaded from "+SIGNALK_CFG_SAVE_FILE);
+				logger.info("   Saved config loaded from "+rootPath+SIGNALK_CFG_SAVE_FILE);
 			}catch(Exception ex){
 				logger.error(ex.getMessage(),ex);
 			}
@@ -149,7 +152,7 @@ public class SignalKModelFactory {
 	}
 	
 	private static void loadConfig(SignalKModel model, String self){
-		File jsonFile = new File(SIGNALK_CFG_SAVE_FILE);
+		File jsonFile = new File(rootPath+SIGNALK_CFG_SAVE_FILE);
 		logger.info("Checking for previous config: "+jsonFile.getAbsolutePath());
 		if(jsonFile.exists()){
 			try{
@@ -158,7 +161,7 @@ public class SignalKModelFactory {
 				model.putAll(ser.read(temp));
 				model.put(ConfigConstants.UUID,self);
 				Util.setSelf(self);
-				logger.info("   Saved config loaded from "+SIGNALK_CFG_SAVE_FILE);
+				logger.info("   Saved config loaded from "+rootPath+SIGNALK_CFG_SAVE_FILE);
 				logger.info("   self set to: "+self);
 			}catch(Exception ex){
 				logger.error(ex.getMessage(),ex);
@@ -174,7 +177,7 @@ public class SignalKModelFactory {
 	 */
 	public static void save(SignalKModel model) throws IOException {
 		if (model != null) {
-			File jsonFile = new File(SIGNALK_MODEL_SAVE_FILE);
+			File jsonFile = new File(rootPath+SIGNALK_MODEL_SAVE_FILE);
 			JsonSerializer ser = new JsonSerializer();
 			Json modelJson = ser.writeJson(model);
 			//remove config
@@ -182,7 +185,7 @@ public class SignalKModelFactory {
 				modelJson = modelJson.delAt(SignalKConstants.CONFIG);
 			}
 			FileUtils.writeStringToFile(jsonFile, modelJson.toString());
-			logger.debug("   Saved model state to "+SIGNALK_MODEL_SAVE_FILE);
+			logger.debug("   Saved model state to "+rootPath+SIGNALK_MODEL_SAVE_FILE);
 		}
 	}
 	
@@ -192,7 +195,7 @@ public class SignalKModelFactory {
 	 * @throws IOException
 	 */
 	public static void saveConfig(SignalKModel model) throws IOException {
-		saveConfig(model,new File(SIGNALK_CFG_SAVE_FILE));
+		saveConfig(model,new File(rootPath+SIGNALK_CFG_SAVE_FILE));
 	}
 	public static void saveConfig(SignalKModel model, File jsonFile ) throws IOException {
 		if (model != null) {
@@ -206,7 +209,7 @@ public class SignalKModelFactory {
 	    		buffer.append("{}");
 	    	}
 			FileUtils.writeStringToFile(jsonFile, buffer.toString());
-			logger.debug("   Saved model state to "+SIGNALK_CFG_SAVE_FILE);
+			logger.debug("   Saved model state to "+rootPath+SIGNALK_CFG_SAVE_FILE);
 		}
 
 	}

--- a/src/main/java/nz/co/fortytwo/signalk/util/Util.java
+++ b/src/main/java/nz/co/fortytwo/signalk/util/Util.java
@@ -80,6 +80,25 @@ public class Util {
 	private static Pattern selfEndMatch = Pattern.compile("\\.self$");
 	private static String dot_self = dot + self;
 
+	private static String rootPath="";
+
+
+	/**
+         * Set the root path
+         *
+         * @param rootPath
+         */
+        public static void setRootPath(String rootPath) {
+                Util.rootPath=rootPath;
+        }
+
+	/**
+         * Get the root path
+         *
+         * @return
+         */
+        public static String getRootPath() { return rootPath; }
+
 	/**
 	 * Smooth the data a bit
 	 * 
@@ -180,7 +199,7 @@ public class Util {
 		Json msg = Json.object();
 		msg.set(SignalKConstants.version, getVersion());
 		msg.set(SignalKConstants.timestamp, getIsoTimeString());
-		msg.set(self_str, ConfigConstants.UUID);
+		msg.set(self_str, getConfigProperty(ConfigConstants.UUID));
 		return msg;
 	}
 


### PR DESCRIPTION
I added the Util.setRootPath static method in order to change, if needed the SignalK core Java current directory. Is is motivated by the fact Android has no current directory, but a directory were the application is authorised to write.
I fixed a bug on getWekcome method.
